### PR TITLE
Add basic busted test for loading palette

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Neovim
-        uses: rhysd/action-setup-vim@v1
-        with:
-          neovim: true
+        uses: chrisgrieser/setup-neovim@v1
       - name: Install dependencies
         run: |
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim tests/deps/plenary.nvim

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Neovim
+        uses: MunifTanjim/setup-neovim@v1
+      - name: Install dependencies
+        run: |
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim tests/deps/plenary.nvim
+          git clone --depth 1 https://github.com/rktjmp/lush.nvim tests/deps/lush.nvim
+          sudo apt-get update
+          sudo apt-get install -y luarocks
+          sudo luarocks install busted
+      - name: Run tests
+        run: |
+          nvim --headless -u tests/minimal_init.lua \
+            -c "lua require('plenary.busted').run{'tests'}" \
+            -c qa

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Neovim
-        uses: MunifTanjim/setup-neovim@v1
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
       - name: Install dependencies
         run: |
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim tests/deps/plenary.nvim

--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ A simple blue nvim theme
 ![Preview](/assets/preview.png)
 
 ![Preview React](/assets/preview.react.png)
+
+### Running tests
+
+After cloning the test dependencies you can run the suite with `busted` under
+Neovim:
+
+```bash
+nvim --headless -u tests/minimal_init.lua \
+  -c "lua require('plenary.busted').run{'tests'}" \
+  -c qa
+```

--- a/lua/pizazz/init.lua
+++ b/lua/pizazz/init.lua
@@ -6,7 +6,8 @@ return {
 	dark = get_theme(palette.dark),
 	light = get_theme(palette.light),
 	load = function(flavor)
-		local theme = flavor == "light" and require("pizzaz").light or require("pizzaz").dark
+		local mod = require("pizazz")
+		local theme = flavor == "light" and mod.light or mod.dark
 		lush(theme)
 	end,
 }

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,5 @@
+-- Add plugin and dependencies to runtimepath
+local root = vim.fn.fnamemodify('..', ':p')
+vim.opt.rtp:append(root .. '/tests/deps/plenary.nvim')
+vim.opt.rtp:append(root .. '/tests/deps/lush.nvim')
+vim.opt.rtp:append(root)

--- a/tests/test_load.lua
+++ b/tests/test_load.lua
@@ -1,0 +1,14 @@
+local busted = require('busted')
+
+describe("pizazz.load", function()
+  it("applies the light palette", function()
+    local pizazz = require('pizazz')
+    pizazz.load('light')
+    local hl = vim.api.nvim_get_hl_by_name('Normal', true)
+    local p = require('pizazz.palette').light
+    local fg = string.format('#%06x', hl.foreground)
+    local bg = string.format('#%06x', hl.background)
+    assert.are.same(p.text_primary.hex, fg)
+    assert.are.same(p.bg_main.hex, bg)
+  end)
+end)


### PR DESCRIPTION
## Summary
- fix `load()` to require the correct module
- add a `tests` directory with a busted test
- create minimal init for tests
- add GitHub Actions workflow for running tests
- document running tests in README
- fix indentation in init.lua

## Testing
- `nvim --headless -u tests/minimal_init.lua -c "lua require('plenary.busted').run{'tests'}" -c qa` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888bbbaaf8832d863cdca031611e44